### PR TITLE
feat(api/annotations): #30 - Add Swagger Annotations with Rename Base…

### DIFF
--- a/services/pom.xml
+++ b/services/pom.xml
@@ -40,6 +40,11 @@
 				</exclusion>
 			</exclusions>
 		</dependency>
+		<dependency>
+			<groupId>org.springdoc</groupId>
+			<artifactId>springdoc-openapi-ui</artifactId>
+			<version>1.4.4</version>
+		</dependency>
 	</dependencies>
 
 	<build>

--- a/services/src/main/java/io/trello/trelloapp/SwaggerConfig.java
+++ b/services/src/main/java/io/trello/trelloapp/SwaggerConfig.java
@@ -1,0 +1,22 @@
+package io.trello.trelloapp;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.info.Info;
+import io.swagger.v3.oas.models.info.License;
+
+@Configuration
+public class SwaggerConfig {
+
+    @Bean
+    public OpenAPI customOpenAPI() {
+        return new OpenAPI()
+            .info(new Info()
+            .title("Trello Clone App API Docs")
+            .version("0.1")
+            .description("Below Docs helps to understand the Trello App Documentation")
+            .termsOfService("http://swagger.io/terms/")
+            .license(new License().name("Apache 2.0").url("http://springdoc.org")));
+    }
+}

--- a/services/src/main/java/io/trello/trelloapp/TrelloCloneApp.java
+++ b/services/src/main/java/io/trello/trelloapp/TrelloCloneApp.java
@@ -4,10 +4,10 @@ import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 
 @SpringBootApplication
-public class DemoApplication {
+public class TrelloCloneApp {
 
 	public static void main(String[] args) {
-		SpringApplication.run(DemoApplication.class, args);
+		SpringApplication.run(TrelloCloneApp.class, args);
 	}
 
 }

--- a/services/src/main/resources/application.properties
+++ b/services/src/main/resources/application.properties
@@ -1,1 +1,3 @@
-
+springdoc.swagger-ui.path=/swagger
+springdoc.swagger-ui.configUrl=/v3/api-docs
+springdoc.swagger-ui.disable-swagger-default-url=false

--- a/services/src/test/java/io/trello/trelloapp/TrelloCloneAppTests.java
+++ b/services/src/test/java/io/trello/trelloapp/TrelloCloneAppTests.java
@@ -4,7 +4,7 @@ import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;
 
 @SpringBootTest
-class DemoApplicationTests {
+class TrelloCloneAppTests {
 
 	@Test
 	void contextLoads() {


### PR DESCRIPTION
## Steps To Implement Feature

1. Added Swagger V3 `springdoc-openapi-ui` Maven Dependency for Auto Generate API Doc.
2. Added Class SwaggerConfig.java will be packaged with Project. below lines are config.

```
public OpenAPI customOpenAPI() {
        return new OpenAPI()
            .info(new Info()
            .title("Trello Clone App API Docs")
            .version("0.1")
            .description("Below Docs helps to understand the Trello App Documentation")
            .termsOfService("http://swagger.io/terms/")
            .license(new License().name("Apache 2.0").url("http://springdoc.org")));
    }
```

Closes issue #30 

![image](https://user-images.githubusercontent.com/1652629/90337482-5ac4bf80-e015-11ea-8ec1-bfcf581c5db1.png)
